### PR TITLE
bug/certifi vuln

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,10 @@
   }:
     flake-utils.lib.eachDefaultSystem (system: let
       userOverlays = builtins.readDir ./python/overlays;
+      basicPkgsForSystem = system:
+        import nixpkgs {
+          inherit system;
+        };
       pkgsForSystem = system:
         import nixpkgs {
           system = system;
@@ -20,13 +24,14 @@
               userOverlays);
         };
       pkgs = pkgsForSystem system;
+      simplePkgs = basicPkgsForSystem system;
       nix2containerPkgs = nix2container.packages.${system};
     in {
       packages = import ./python {
         inherit pkgs;
         inherit nix2containerPkgs;
       };
-      devShell = pkgs.mkShell {
+      devShell = simplePkgs.mkShell {
         buildInputs = with pkgs; [
           trivy
           grype

--- a/python/overlays/python-certifi.nix
+++ b/python/overlays/python-certifi.nix
@@ -1,0 +1,16 @@
+final: prev: {
+  pythonPackagesExtensions =
+    prev.pythonPackagesExtensions
+    ++ [
+      (python-final: python-prev: {
+        certifi = python-prev.certifi.overridePythonAttrs (oldAttrs: {
+          src = prev.fetchFromGitHub {
+            owner = oldAttrs.pname;
+            repo = "python-certifi";
+            rev = "2023.07.22";
+            hash = "sha256-V3bptJDNMGXlCMg6GHj792IrjfsG9+F/UpQKxeM0QOc=";
+          };
+        });
+      })
+    ];
+}


### PR DESCRIPTION
- update certifi: 2022.12.07 -> 2023.07.22
closes #20 

Current status of this package on repology: https://repology.org/project/python:certifi/versions